### PR TITLE
Fix test case's dependency on chai version

### DIFF
--- a/test/query.js
+++ b/test/query.js
@@ -98,7 +98,9 @@ describe('Query', function () {
     it('should allow nested array value to be set', function () {
       var obj = {};
       filtr.setPathValue('hello.universe[1].filtr', 'galaxy', obj);
-      obj.should.eql({ hello: { universe: [ , { filtr: 'galaxy' } ] }});
+      var expected = { hello: { universe: { '1': [] } } };
+      expected.hello.universe[1].filtr = 'galaxy';
+      obj.should.eql(expected);
     });
 
     it('should allow value to be REset in simple object', function () {


### PR DESCRIPTION
Make "Query setPathValue should allow nested array value to be set" work with any version of chai. The previous implementation stopped working in chai 1.8.
